### PR TITLE
feat: initial argocd application module, semantic release workflows

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,14 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '*.tf'
+jobs:
+  conventional-commits-pr:
+    if: "github.event.pull_request.draft == false"
+    name: Validate Conventional Commits PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: catalystsquad/action-validate-conventional-commits-pr@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: Release
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - '*.tf'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - uses: catalystsquad/action-semantic-release-general@v1
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,40 @@
+locals {
+  # build a default spec using implmented variables
+  default_application_spec = {
+    "destination" = {
+      "namespace" = "argo-cd"
+      "server"    = "https://kubernetes.default.svc"
+    }
+    "project" = "default"
+    "source" = {
+      "repoURL" = var.source_repo_url
+      "chart"   = var.source_chart
+      "helm" = {
+        "values"  = var.helm_values
+        "version" = "v3"
+      }
+      "targetRevision" = var.source_target_revision
+    }
+    "syncPolicy" = var.sync_policy
+  }
+
+  # allow any spec field to be specified if it isn't implemented in variables
+  application_spec = merge(local.default_application_spec, var.spec_override)
+
+  application = {
+    "apiVersion" = "argoproj.io/v1alpha1"
+    "kind"       = "Application"
+    "metadata" = {
+      "name"      = var.name
+      "namespace" = var.namespace
+    }
+    "spec" = local.application_spec
+  }
+
+  application_yaml = yamlencode(local.application)
+}
+
+resource "kubectl_manifest" "application" {
+  yaml_body        = local.application_yaml
+  sensitive_fields = ["spec.source.helm.values"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,74 @@
+# required
+variable "name" {
+  description = "Name of the ArgoCD application custom resource"
+  type        = string
+}
+
+variable "source_chart" {
+  description = "Name of Helm chart"
+  type        = string
+}
+
+variable "source_repo_url" {
+  description = "Helm repository URL"
+  type        = string
+}
+
+# optional
+variable "helm_values" {
+  description = "Helm values as a raw string in YAML format"
+  type        = string
+  default     = ""
+}
+
+variable "source_target_revision" {
+  type    = string
+  default = ">=1.0.0"
+}
+
+variable "spec_override" {
+  type    = map(any)
+  default = {}
+}
+
+variable "sync_policy" {
+  type         = object({
+    automated  = object({
+      prune    = bool
+      selfHeal = bool
+    })
+    retry           = object({
+      backoff       = object({
+        duration    = string
+        factor      = number
+        maxDuration = string
+      })
+      limit   = number
+    })
+    syncOptions = list(string)
+  })
+  default = {
+    "automated" = {
+      "prune"    = true
+      "selfHeal" = true
+    }
+    "retry" = {
+      "backoff" = {
+        "duration"    = "5s"
+        "factor"      = 2
+        "maxDuration" = "3m"
+      }
+      "limit" = 3
+    }
+    "syncOptions" = [
+      "CreateNamespace=true",
+      "PrunePropagationPolicy=foreground",
+      "PruneLast=true",
+    ]
+  }
+}
+
+variable "namespace" {
+  type    = string
+  default = "argo-cd"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    kubectl = {
+      source = "gavinbunney/kubectl"
+      version = "~> 1.14.0"
+    }
+  }
+}


### PR DESCRIPTION
simple module so far which allows deploying an argocd custom resource utilizing the kubectl terraform provider. defaults currently only support deploying a helm application, which is the only thing we use right now. implements a "spec_override" variable which would allow configuring any unimplemented field. as our use-cases grow, we can expand on the functionality of this module.